### PR TITLE
Prefix log message command list entries with !

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1309,10 +1309,10 @@ impl EventHandler for Bot {
         
         // Log available commands
         let command_list = self.commands.keys()
-            .map(|k| k.as_str())
+            .map(|k| format!("!{}", k))
             .collect::<Vec<_>>()
             .join(", ");
-        info!("Available commands: !{}", command_list);
+        info!("Available commands: {}", command_list);
         
         // Log keyword triggers
         info!("Keyword triggers:");


### PR DESCRIPTION
Instead of: 

`2025-05-14T21:42:43.507080Z  INFO crow: Available commands: !help, hello`

Now it's:

`2025-05-14T21:42:43.507080Z  INFO crow: Available commands: !help, !hello`