### PR TITLE
Add build workflow to repo

### DIFF
--- a/.github/workflows/cargobuild.yml
+++ b/.github/workflows/cargobuild.yml
@@ -16,3 +16,5 @@ jobs:
     - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
+    - name: Test
+      run: cargo test --verbose

--- a/.github/workflows/cargobuild.yml
+++ b/.github/workflows/cargobuild.yml
@@ -1,0 +1,18 @@
+name: cargo build
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose


### PR DESCRIPTION
This adds a GitHub Action workflow which will run `cargo build` and `cargo test` when there's a pull request or push to the repo.

It can be locked down by branch by modifying the `on` section to: 

```yaml
on:
  push:
    branches: [ "main" ]
  pull_request:
    branches: [ "main" ]
```